### PR TITLE
feat(date): add MustDateFromStr

### DIFF
--- a/date.go
+++ b/date.go
@@ -35,6 +35,14 @@ func NewDateFromStr(str string) (Date, error) {
 	return NewDateFromStrWithFormat(dateStrFormat, str)
 }
 
+func MustDateFromStr(str string) Date {
+	date, err := NewDateFromStr(str)
+	if err != nil {
+		panic(err)
+	}
+	return date
+}
+
 func (d *Date) UnmarshalJSON(data []byte) error {
 	t, err := time.Parse("\"2006-01-02\"", string(data))
 	*d = Date{t}


### PR DESCRIPTION
## Why
ハードコードした文字列リテラルからDateを生成するときに呼び出し側でエラーハンドリングするのは冗長

## What
エラー発生時にpanicするMustDateFromStrを追加