### PR TITLE
fix(date): fix date format when marshaling

### DIFF
--- a/date.go
+++ b/date.go
@@ -49,8 +49,8 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 	return err
 }
 
-func (d *Date) MarshalJSON() ([]byte, error) {
-	return json.Marshal(d.Format("2006-01-02"))
+func (d Date) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
 }
 
 func (d Date) PlusNDay(n int) Date {
@@ -97,7 +97,7 @@ func (d Date) ToStringWithFormat(format string) string {
 	return d.Format(format)
 }
 
-func (d Date) ToString() string {
+func (d Date) String() string {
 	return d.ToStringWithFormat(dateStrFormat)
 }
 
@@ -115,7 +115,7 @@ func (d Date) Value() (driver.Value, error) {
 func (dates Dates) ToStringArray() []string {
 	ret := []string{}
 	for _, date := range dates {
-		ret = append(ret, date.ToString())
+		ret = append(ret, date.String())
 	}
 	return ret
 }

--- a/date_test.go
+++ b/date_test.go
@@ -1,6 +1,7 @@
 package mdate
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 )
@@ -188,6 +189,32 @@ func TestDate_JapanFiscalYear(t *testing.T) {
 	for _, tt := range tests {
 		if tt.in.JapanFiscalYear() != tt.want {
 			t.Error(tt)
+		}
+	}
+}
+
+func TestDate_MarshalJSON(t *testing.T) {
+
+	type Sample struct {
+		D Date `json:"d"`
+	}
+
+	tests := []struct {
+		in   Sample
+		want string
+	}{
+		{
+			in:   Sample{D: NewDate(2020, 2, 2)},
+			want: `{"d":"2020-02-02"}`,
+		},
+	}
+	for _, tt := range tests {
+		b, err := json.Marshal(tt.in)
+		if err != nil {
+			t.Error(err)
+		}
+		if tt.want != string(b) {
+			t.Error(string(b), tt.want)
 		}
 	}
 }


### PR DESCRIPTION
MarshalJSONのレシーバをポインタにしていたせいで,mdate.Dateがpointerじゃないとき望ましい形式で出力されない問題を修正