### PR TITLE
fix(module): fix module path to v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/matsuri-tech/date-go
+module github.com/matsuri-tech/date-go/v2
 
 go 1.13
 


### PR DESCRIPTION
メジャーバージョンを2以上にする場合は,基本的に後方互換性がないと思われるので,module pathを変えろって怒られたので修正

参考
https://blog.golang.org/v2-go-modules
