### PR TITLE
chore(date): add MarshalText()

### DIFF
--- a/date.go
+++ b/date.go
@@ -59,7 +59,7 @@ func (d Date) MarshalJSON() ([]byte, error) {
 }
 
 func (d Date) MarshalText() (text []byte, err error) {
-	return []byte(fmt.Sprintf("%v", d.String())), nil
+	return []byte(d.String()), nil
 }
 
 func (d Date) PlusNDay(n int) Date {

--- a/date.go
+++ b/date.go
@@ -3,7 +3,6 @@ package mdate
 import (
 	"database/sql/driver"
 	"encoding/json"
-	"fmt"
 	"time"
 )
 

--- a/date.go
+++ b/date.go
@@ -3,6 +3,7 @@ package mdate
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"time"
 )
 
@@ -55,6 +56,10 @@ func (d *Date) UnmarshalJSON(data []byte) error {
 
 func (d Date) MarshalJSON() ([]byte, error) {
 	return json.Marshal(d.String())
+}
+
+func (d Date) MarshalText() (text []byte, err error) {
+	return []byte(fmt.Sprintf("%v", d.String())), nil
 }
 
 func (d Date) PlusNDay(n int) Date {

--- a/date_test.go
+++ b/date_test.go
@@ -218,3 +218,34 @@ func TestDate_MarshalJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestDate_MarshalJSONInKey(t *testing.T) {
+	type Sample map[Date]Date
+	day1, err := NewDateFromStr("2022-01-01")
+	if err != nil {
+		t.Errorf("error: %v", err)
+	}
+	tests := []struct {
+		caseName string
+		in       Sample
+		want     []byte
+	}{
+		{
+			caseName: "simple",
+			in: Sample{
+				day1: day1,
+			},
+			want: []byte("{\"2022-01-01\": \"2022-01-01\"}"),
+		},
+	}
+
+	for _, tt := range tests {
+		s, err := json.Marshal(tt.in)
+		if err != nil {
+			t.Errorf("caseName: %v, err occurs in Marshal. err: %v", tt.caseName, err)
+		}
+		if !reflect.DeepEqual(s, tt.want) {
+			t.Errorf("caseName: %v, result: %v, expected: %v", tt.caseName, string(s), string(tt.want))
+		}
+	}
+}

--- a/date_test.go
+++ b/date_test.go
@@ -235,7 +235,7 @@ func TestDate_MarshalJSONInKey(t *testing.T) {
 			in: Sample{
 				day1: day1,
 			},
-			want: []byte("{\"2022-01-01\": \"2022-01-01\"}"),
+			want: []byte("{\"2022-01-01\":\"2022-01-01\"}"),
 		},
 	}
 


### PR DESCRIPTION
# why

KeyNameにDateを入れると、Marshalしたときに日付だけではなく時刻までついてきてしまう

Closes: #22 